### PR TITLE
Introduces new ENV VAR for GitHub Org

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       ES_HOST: elasticsearch
       ES_PORT: 9200
       github_oauth: ${github_oauth}
+      github_org: ${github_org}
     command: /bin/sh -c "sleep 100 && java -cp /osstracker-scraperapp-all.jar com.netflix.oss.tools.osstrackerscraper.app.RunGithubScraper --action updatecassandra"
 
   osstracker-scraper-elasticsearch:
@@ -82,4 +83,5 @@ services:
       ES_HOST: elasticsearch
       ES_PORT: 9200
       github_oauth: ${github_oauth}
+      github_org: ${github_org}
     command: /bin/sh -c "sleep 160 && java -cp /osstracker-scraperapp-all.jar com.netflix.oss.tools.osstrackerscraper.app.RunGithubScraper --action updateelasticsearch"

--- a/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/Conf.scala
+++ b/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/Conf.scala
@@ -28,5 +28,4 @@ object Conf {
   val SENTINAL_DEV_LEAD_ID = "111111"; // Assign to valid emp id
   val SENTINAL_MGR_LEAD_ID = "222222"; // Assign to valid emp id
   val SENTINAL_ORG = "UNKNOWN"; // Assign to unknown org until edited in console
-  val GITHUB_ORG = "Netflix"
 }

--- a/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/GithubAccess.scala
+++ b/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/GithubAccess.scala
@@ -159,6 +159,7 @@ class GithubAccess(val asOfYYYYMMDD: String, val asOfISO: String) {
   def getAllRepositoriesForOrg(githubOrg: String): List[GHRepository] = {
     val org = github.getOrganization(githubOrg)
     val githubRepos = org.listRepositories(100).asList().toList
+    logger.info(s"Found ${githubRepos.size} total repos for ${githubOrg}")
     githubRepos
   }
 

--- a/osstracker-scraperapp/Dockerfile
+++ b/osstracker-scraperapp/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER NetflixOSS <netflixoss@netflix.com>
 COPY build/libs/osstracker-scraperapp-*-all.jar /osstracker-scraperapp-all.jar
 
 ENV github_oauth=1111111111111111111111111111111111111111
+ENV github_org=Netflix
 ENV github_login=yourloginhere
 
 CMD ["java", "-jar", "/osstracker-scraperapp-all.jar", "--action", "updatecassandra"]

--- a/osstracker-scraperapp/build.gradle
+++ b/osstracker-scraperapp/build.gradle
@@ -24,8 +24,9 @@ task runScraper(type: JavaExec, dependsOn: classes) {
     main = 'com.netflix.oss.tools.osstrackerscraper.app.RunGithubScraper'
 
     environment = [
-        // You should update with your github OAUTH token
+        // You should update with your github OAUTH token and org
         "github_oauth" : "1111111111111111111111111111111111111111",
+        "github_org" : "Netflix",
         // You should update with a a cassandra host and port
         "CASS_HOST" : CASS_HOST,
         "CASS_PORT" : "7104",

--- a/osstracker-scraperapp/src/main/scala/com/netflix/oss/tools/osstrackerscraper/app/RunGithubScraper.scala
+++ b/osstracker-scraperapp/src/main/scala/com/netflix/oss/tools/osstrackerscraper/app/RunGithubScraper.scala
@@ -32,8 +32,10 @@ object RunGithubScraper {
     val esHost = System.getenv("ES_HOST")
     val esPort = System.getenv("ES_PORT").toInt
 
+    val githubOrg = System.getenv("github_org")
+
     if (action == Conf.ACTION_UPDATE_CASSANDRA) {
-      val scraper = new GithubScraper(Conf.GITHUB_ORG, cassHost, cassPort, esHost, esPort, ConsoleReportWriter)
+      val scraper = new GithubScraper(githubOrg, cassHost, cassPort, esHost, esPort, ConsoleReportWriter)
       val success = scraper.updateCassandra()
       if (!success) {
         System.exit(1)
@@ -41,7 +43,7 @@ object RunGithubScraper {
       logger.info(s"successfully updated the cassandra repo infos")
     }
     else if (action == Conf.ACTION_UPDATE_ELASTICSEARCH) {
-      val scraper = new GithubScraper(Conf.GITHUB_ORG, cassHost, cassPort, esHost, esPort, ConsoleReportWriter)
+      val scraper = new GithubScraper(githubOrg, cassHost, cassPort, esHost, esPort, ConsoleReportWriter)
       val success = scraper.updateElasticSearch()
       if (!success) {
         System.exit(1)


### PR DESCRIPTION
Extracted the hard-coded "Netflix" value as an environment variable that can now be passed to the `docker-compose up` command. All repos under specific org will then be processed accordingly.

By default, "Netflix" is the GitHub Org that will be processed.