### PR TITLE
Add infra-as-code deployment example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.ipr
 .idea/
 osstracker-scrapernetflixapp
+out/

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,2 @@
+roles/external
+production.ini

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,44 @@
+# Configuration Management through Ansible 
+
+This directory provides the necessary configuration management steps that set up a single server for OSS Tracker deployment via `docker-compose`.
+
+## Requirements
+
+1. Setup Ansible on your machine: https://docs.ansible.com/ansible/latest/intro_installation.html 
+1. Install python requirements (consider using bundled `extensions/setup/setup.sh`)
+2. Update roles (consider using `extensions/setup/role_update.sh`)
+
+
+## Run Ansible
+
+Run the osstracker playbook, like so: 
+
+```bash
+cd ansible/plays
+ansible-playbook -i ../production.ini osstracker.yml
+```
+
+The playbook installs docker, docker-compose and copies over the `docker-compose.yml` and `osstracker-ddl` directories. 
+
+Once that's done, all you have to do is ssh into the new host and run: 
+
+```bash
+sudo su -
+cd /opt/osstracker
+export github_oauth= # your github api key - you'll need this for overcoming rate limiting.
+export github_org= # the github organization whose repositories you want to track
+docker-compose up --no-deps -d 
+```
+
+That's it!! Please _DO_ wait a few minutes though to give the scrapers some time to insert the first data.  
+
+## Kibana Setup
+
+1. After a few mins, go to the index mapping and select `osstracker`. Then use the `asOfYYYYMMDD` field for time. 
+1. Restore visualizations: Upload the `visualizations.json` and `dashboard.json` files you'll find in the `kibana-dashboards` directory of this project.
+
+Please note the 2nd dashboard might take a day till it shows the first data and a couple of days to make more sense. This is because there is a single entry per day for each project.
+
+Enjoy!!! 
+
+

--- a/ansible/extensions/setup/python_requirements.txt
+++ b/ansible/extensions/setup/python_requirements.txt
@@ -1,0 +1,10 @@
+# Required python packages for ansible
+PyYAML
+Jinja2
+httplib2
+
+# Ansible
+ansible
+
+#Other packages
+boto

--- a/ansible/extensions/setup/role_update.sh
+++ b/ansible/extensions/setup/role_update.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+#TODO: Support python virtual environments for now global
+
+COLOR_END='\e[0m'
+COLOR_RED='\e[0;31m'
+
+# This current directory.
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR=$(cd "$DIR/../../" && pwd)
+EXTERNAL_ROLE_DIR="$ROOT_DIR/roles/external"
+ROLES_REQUIREMNTS_FILE="$ROOT_DIR/roles/roles_requirements.yml"
+
+# Exit msg
+msg_exit() {
+    printf "$COLOR_RED$@$COLOR_END"
+    printf "\n"
+    printf "Exiting...\n"
+    exit 1
+}
+
+# Trap if ansible-galaxy failed and warn user
+cleanup() {
+    msg_exit "Update failed. Please don't commit or push roles till you fix the issue"
+}
+trap "cleanup"  ERR INT TERM
+
+# Check ansible-galaxy
+[[ -z "$(which ansible-galaxy)" ]] && msg_exit "Ansible is not installed or not in your path."
+
+# Check roles req file
+[[ ! -f "$ROLES_REQUIREMNTS_FILE" ]]  && msg_exit "roles_requirements '$ROLES_REQUIREMNTS_FILE' does not exist or permssion issue.\nPlease check and rerun."
+
+# Remove existing roles
+if [ -d "$EXTERNAL_ROLE_DIR" ]; then
+    cd "$EXTERNAL_ROLE_DIR"
+	if [ "$(pwd)" == "$EXTERNAL_ROLE_DIR" ];then
+	  echo "Removing current roles in '$EXTERNAL_ROLE_DIR/*'"
+	  rm -rf *
+	else
+	  msg_exit "Path error could not change dir to $EXTERNAL_ROLE_DIR"
+	fi
+fi
+
+
+
+# Install roles
+ansible-galaxy install -r "$ROLES_REQUIREMNTS_FILE" --force --no-deps -p "$EXTERNAL_ROLE_DIR"
+
+exit 0

--- a/ansible/extensions/setup/setup.sh
+++ b/ansible/extensions/setup/setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+#TODO: Support python virtual environments for now global
+
+COLOR_END='\e[0m'
+COLOR_RED='\e[0;31m' # Red
+COLOR_YEL='\e[0;33m' # Yellow
+# This current directory.
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR=$(cd "$DIR/../../" && pwd)
+
+PYTHON_REQUIREMNTS_FILE="$DIR/python_requirements.txt"
+
+msg_exit() {
+    printf "$COLOR_RED$@$COLOR_END"
+    printf "\n"
+    printf "Exiting...\n"
+    exit 1
+}
+
+msg_warning() {
+    printf "$COLOR_YEL$@$COLOR_END"
+    printf "\n"
+}
+# Check your environment 
+system=$(uname)
+
+if [ "$system" == "Linux" ]; then
+    distro=$(lsb_release -i)
+    if [[ $distro == *"Ubuntu"* ]] || [[ $distro == *"Debian"* ]] ;then
+        msg_warning "Your running Debian based linux.\n You might need to install 'sudo apt-get install build-essential python-dev\n."
+        # TODO: check if ubuntu and install build-essential, and python-dev
+    else
+        msg_warning "Your linux system was not test"
+    fi
+fi
+
+
+# Check if root
+# Since we need to make sure paths are okay we need to run as normal user he will use ansible
+[[ "$(whoami)" == "root" ]] && msg_exit "Please run as a normal user not root"
+
+# Check python
+[[ -z "$(which python)" ]] && msg_exit "Opps python is not installed or not in your path."
+# Check pip
+[[ -z "$(which pip)" ]] && msg_exit "pip is not installed!\nYou can try'sudo easy_install pip'"
+# Check python file
+[[ ! -f "$PYTHON_REQUIREMNTS_FILE" ]]  && msg_exit "python_requirements '$PYTHON_REQUIREMNTS_FILE' does not exist or permssion issue.\nPlease check and rerun."
+
+# Install 
+# By default we upgrade all packges to latest. if we need to pin packages use the python_requirements
+echo "This script install python packages defined in '$PYTHON_REQUIREMNTS_FILE' "
+echo "Since we only support global packages installation for now we need root password."
+echo "You will be asked for your password."
+sudo -H pip install --no-cache-dir  --upgrade --requirement "$PYTHON_REQUIREMNTS_FILE"
+
+
+#Touch vpass
+echo "Touching vpass"
+if [ -w "$ROOT_DIR" ]
+then
+   touch "$ROOT_DIR/.vpass"
+else
+  sudo touch "$ROOT_DIR/.vpass"
+fi
+exit 0

--- a/ansible/plays/ansible.cfg
+++ b/ansible/plays/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+roles_path=../roles/internal:../roles/external
+#vault_password_file=../vpass

--- a/ansible/plays/osstracker.yml
+++ b/ansible/plays/osstracker.yml
@@ -1,0 +1,54 @@
+---
+
+- name: Base setup
+  hosts: osstracker
+  become: true
+  roles:
+    - tersmitten.locales
+  tasks:
+    - name: Run the equivalent of "apt-get update" as a separate step
+      apt:
+        update_cache: yes
+    - name: Install unattended-upgrades for security updates
+      apt:
+        pkg: unattended-upgrades
+        state: present
+# UNCOMMENT BELOW IF YOU WANT AUTOMATED REBOOTS
+#    - name: Install update-notifier-common for automated reboots
+#      apt:
+#        pkg: update-notifier-common
+#        state: present
+#    - name: enable automatic reboots
+#      lineinfile:
+#        path: /etc/apt/apt.conf.d/50unattended-upgrades
+#        regexp: '^//Unattended-Upgrade::Automatic-Reboot "false";'
+#        line: 'Unattended-Upgrade::Automatic-Reboot "true";'
+#    - name: enable automatic reboots at 2am
+#      lineinfile:
+#        path: /etc/apt/apt.conf.d/50unattended-upgrades
+#        regexp: '//Unattended-Upgrade::Automatic-Reboot-Time "02:00";'
+#        line: 'Unattended-Upgrade::Automatic-Reboot-Time "02:00";'
+
+- name: Install Docker
+  hosts: osstracker
+  become: true
+  roles:
+    - angstwad.docker_ubuntu
+
+- name: Install Docker Compose
+  hosts: osstracker
+  roles:
+    - Bessonov.docker-compose
+
+- name: Deploy OSSTracker
+  hosts: osstracker
+  become: true
+  tasks:
+    - copy:
+        src: ../../docker-compose.yml
+        dest: /opt/osstracker/
+        mode: 0644
+    - copy:
+        src: ../../osstracker-ddl
+        dest: /opt/osstracker/
+        mode: 0644

--- a/ansible/roles/roles_requirements.yml
+++ b/ansible/roles/roles_requirements.yml
@@ -1,0 +1,9 @@
+- src: https://github.com/angstwad/docker.ubuntu
+  #version: "v1.0.1"
+  name: angstwad.docker_ubuntu
+
+- src: https://github.com/Bessonov/ansible-role-docker-compose
+  #version: "v1.0.1"
+  name: Bessonov.docker-compose
+
+- name: tersmitten.locales

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,35 @@
+# Deployment Example 
+
+This directory contains a simple way to deploy the Netflix OSS Tracker on a single AWS EC2 server, utilizing Terraform. 
+
+## 1. Requirements
+
+1. Install Terraform: https://www.terraform.io/intro/getting-started/install.html
+1. Setup Terraform for AWS access: https://www.terraform.io/docs/providers/aws/
+1. Setup your own variables:
+
+Create a file `terraform/aws/osstracker.auto.tfvars`, like so:  
+```
+aws_region = "eu-west-1"
+availability_zone = "eu-west-1a"
+vpc_cidr = "6.7.7.0/24"
+key_name = "" # an EC2 key pair name. Please ensure this is in the same Region as the `aws_region` above.
+private_key_path = "" # the path to the private key of the EC2 key pair above. 
+```
+
+## 2. Run
+
+```bash
+cd terraform/aws
+terraform plan -var-file=osstracker.auto.tfvars .
+# review the output to ensure terraform will do what you expect it to. 
+
+# Then:
+terraform apply -var-file=osstracker.auto.tfvars .
+```
+
+## 3. All set! Let's move to Ansible.
+
+At this point Terraform will have created the inventory file that Ansible will need to run in: `$PROJECT_ROOT/ansible/production.ini`. 
+
+Head on over to `$PROJECT_ROOT/ansible/README.md` for more instructions.

--- a/terraform/aws/.gitignore
+++ b/terraform/aws/.gitignore
@@ -1,0 +1,1 @@
+osstracker.auto.tfvars

--- a/terraform/aws/ec2.tf
+++ b/terraform/aws/ec2.tf
@@ -1,0 +1,94 @@
+resource "aws_security_group" "osstracker_sg" {
+  name        = "osstracker_sg"
+  description = "Opens up access to Netflix OSS Tracker console"
+  vpc_id      = "${aws_vpc.osstracker_vpc.id}"
+
+  # outbound internet access
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+resource "aws_security_group_rule" "allow_ssh" {
+  type            = "ingress"
+  from_port       = 22
+  to_port         = 22
+  protocol        = "tcp"
+  cidr_blocks     = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.osstracker_sg.id}"
+}
+resource "aws_security_group_rule" "allow_console" {
+  type            = "ingress"
+  from_port       = 3000
+  to_port         = 3000
+  protocol        = "tcp"
+  cidr_blocks     = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.osstracker_sg.id}"
+}
+resource "aws_security_group_rule" "allow_kibana" {
+  type            = "ingress"
+  from_port       = 5601
+  to_port         = 5601
+  protocol        = "tcp"
+  cidr_blocks     = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.osstracker_sg.id}"
+}
+
+resource "aws_instance" "osstracker" {
+  connection {
+    user = "ubuntu"
+    private_key = "${file(var.private_key_path)}"
+  }
+  associate_public_ip_address = true
+
+  instance_type = "t2.small"
+
+  ami = "${data.aws_ami.ubuntu.id}"
+
+  key_name = "${var.key_name}" # assumes it exists
+
+  # Our Security group to allow HTTP and SSH access
+  vpc_security_group_ids = ["${aws_security_group.osstracker_sg.id}"]
+
+  subnet_id = "${aws_subnet.osstracker_subnet.id}"
+
+  tags {
+    Name = "osstracker"
+  }
+
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo apt-get -y update",
+    ]
+  }
+  provisioner "remote-exec" {
+    script = "../files/wait_for_instance.sh"
+  }
+
+}
+
+data "template_file" "ansible_inventory" {
+    template = "${file("${path.module}/../templates/ansible_inventory.tpl")}"
+
+    vars {
+        connection_strings = "${join("\n",formatlist("%s ansible_ssh_host=%s ansible_ssh_user=ubuntu ansible_ssh_private_key_file=%s",aws_instance.osstracker.*.tags.Name, aws_instance.osstracker.*.public_ip, var.private_key_path))}"
+        list_nodes = "${join("\n",aws_instance.osstracker.*.tags.Name)}"
+    }
+}
+
+resource "null_resource" "inventories" {
+  triggers {
+    template = "${data.template_file.ansible_inventory.rendered}"
+  }
+
+  provisioner "local-exec" {
+      command = "echo '${data.template_file.ansible_inventory.rendered}' > ../../ansible/production.ini"
+  }
+
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,3 @@
+output "address" {
+  value = "${aws_instance.osstracker.public_ip}"
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+variable "aws_region" {
+  description = "AWS region to launch servers."
+  default     = "eu-west-1"
+}
+variable "availability_zone" {
+  default = "eu-west-1a"
+}
+variable "vpc_cidr" {
+  default = "6.7.7.0/24" # you're wondering, right? well... 677 -> OSS
+}
+variable "key_name" {
+  description = "Desired name of AWS key pair"
+}
+variable "private_key_path" {
+  description = <<DESCRIPTION
+Path to the SSH public key to be used for authentication.
+Ensure this keypair is added to your local SSH agent so provisioners can
+connect.
+Example: ~/.ssh/terraform.pub
+DESCRIPTION
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+

--- a/terraform/aws/vpc.tf
+++ b/terraform/aws/vpc.tf
@@ -1,0 +1,23 @@
+
+# Create a VPC to launch our instances into
+resource "aws_vpc" "osstracker_vpc" {
+  cidr_block = "${var.vpc_cidr}"
+}
+
+# Create an internet gateway to give our subnet access to the outside world
+resource "aws_internet_gateway" "default" {
+  vpc_id = "${aws_vpc.osstracker_vpc.id}"
+}
+# Grant the VPC internet access on its main route table
+resource "aws_route" "internet_access" {
+  route_table_id         = "${aws_vpc.osstracker_vpc.main_route_table_id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.default.id}"
+}
+
+resource "aws_subnet" "osstracker_subnet" {
+  vpc_id            = "${aws_vpc.osstracker_vpc.id}"
+  availability_zone = "${var.availability_zone}"
+  cidr_block        = "${cidrsubnet(aws_vpc.osstracker_vpc.cidr_block, 4, 1)}"
+  map_public_ip_on_launch = true
+}

--- a/terraform/files/wait_for_instance.sh
+++ b/terraform/files/wait_for_instance.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
+  echo -e "\033[1;36mWaiting for cloud-init..."
+  sleep 1
+done

--- a/terraform/templates/ansible_inventory.tpl
+++ b/terraform/templates/ansible_inventory.tpl
@@ -1,0 +1,9 @@
+${connection_strings}
+
+[osstracker]
+${list_nodes}
+
+
+[all:vars]
+environment=prod
+ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
Uses terraform + ansible to deploy OSS Tracker to a single AWS EC2 server (e.g. t2.small). 

More details in the bundled `terraform/README.md` and `ansible/README.md`.