### PR TITLE
Substituted stacktrace with WARN log, if `OSSMETADATA` does not exist

### DIFF
--- a/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/GithubAccess.scala
+++ b/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/GithubAccess.scala
@@ -56,6 +56,11 @@ class GithubAccess(val asOfYYYYMMDD: String, val asOfISO: String, val connectToG
       OssLifecycleParser.getOssLifecycle(osslc)
     }
     catch {
+      case fnfe: java.io.FileNotFoundException => {
+        //simply don't have OSSMETADATA file in project. no need to flood logs with exceptions.
+        logger.warn(s"OSSMETADATA file not found in repo: ${repo.getName}")
+        OssLifecycle.Unknown
+      }
       case ioe: IOException  => {
         ioe.printStackTrace()
         OssLifecycle.Unknown


### PR DESCRIPTION
Not everyone's repos already contain the `OSSMETADATA` file, so I don't think it's terribly important to throw piles of stack traces (that rapidly fill up logs) when that happens. 