### PR TITLE
Feature/GitHub downloads

### DIFF
--- a/kibana-dashboards/downloadsVisualizations.json
+++ b/kibana-dashboards/downloadsVisualizations.json
@@ -1,0 +1,30 @@
+[
+  {
+    "_id": "AWJNwWr9xRjHDZlzGOX9",
+    "_type": "visualization",
+    "_source": {
+      "title": "Github Downloads to Date (Total)",
+      "visState": "{\"title\":\"Github Downloads to Date (Total)\",\"type\":\"table\",\"params\":{\"perPage\":200,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":true,\"totalFunc\":\"sum\",\"type\":\"table\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"assets.downloadsCount\",\"customLabel\":\"Total Downloads to Date\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"bucket\",\"params\":{\"field\":\"asOfYYYYMMDD\",\"interval\":\"d\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"Date\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"repo_name\",\"size\":50,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"GitHub Project\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"release_name.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Releases\"}}],\"listeners\":{}}",
+      "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"AWJNeisdxRjHDZlzGOUN\",\"query\":{\"match_all\":{}},\"filter\":[]}"
+      }
+    }
+  },
+  {
+    "_id": "AWJNyMutxRjHDZlzGOX_",
+    "_type": "visualization",
+    "_source": {
+      "title": "Most Downloaded Projects",
+      "visState": "{\"title\":\"Most Downloaded Projects\",\"type\":\"line\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"Date\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Total Downloads to Date\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"line\",\"mode\":\"normal\",\"data\":{\"label\":\"Total Downloads to Date\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false,\"type\":\"line\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"assets.downloadsCount\",\"customLabel\":\"Total Downloads to Date\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"asOfYYYYMMDD\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"Date\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"repo_name\",\"size\":15,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Github Project\"}}],\"listeners\":{}}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"AWJNeisdxRjHDZlzGOUN\",\"query\":{\"match_all\":{}},\"filter\":[]}"
+      }
+    }
+  }
+]

--- a/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/GithubScraper.scala
+++ b/osstracker-scraper/src/main/scala/com/netflix/oss/tools/osstrackerscraper/GithubScraper.scala
@@ -79,9 +79,19 @@ class GithubScraper(githubOrg: String, cassHost: String, cassPort: Int, esHost: 
 
         if (alreadyExistsDoc.isEmpty) {
           val stat = github.getRepoStats(ghRepo, public, ossLifecycle)
-          val indexed = es.indexDocInES("/osstracker/repo_stats", stat.toString)
+          var indexed = es.indexDocInES("/osstracker/repo_stats", stat.toString)
           if (!indexed) {
             return false
+          } else {
+            val releaseStats = github.getRepoDownloads(ghRepo, public, ossLifecycle)
+
+            releaseStats.foreach( rel => {
+              indexed &= es.indexDocInES("/osstracker/repo_downloads", rel.toString)
+            })
+            if (!indexed) {
+              return false
+            }
+
           }
           docsList += stat
         }


### PR DESCRIPTION
This PR adds functionality to the OSS Tracker that allows you to: 

* Generate a report with the total numbers of downloads to date (in total, per project, and per release).
* View a line chart that shows evolution of downloads (total, project, release) over time  

